### PR TITLE
Update help text with descriptions of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ cargo install --git https://github.com/triarius/riceware
 Usage: riceware [OPTIONS]
 
 Options:
-  -n, --num-words <NUM_WORDS>  [default: 4]
-  -s, --separator <SEPARATOR>  [default: " "]
-  -d, --dict-path <DICT_PATH>
+  -n, --num-words <NUM_WORDS>  The number of words in the passphrase [default: 4]
+  -s, --separator <SEPARATOR>  The string to separate words in the passphrase [default: " "]
+  -d, --dict-path <DICT_PATH>  A path to a dictionary file. A builtin dictionary is used if not provided
   -h, --help                   Print help
   -V, --version                Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,15 @@ use eyre::Result;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
+    /// The number of words in the passphrase
     #[arg(short, long, default_value = "4")]
     num_words: usize,
 
+    /// The string to separate words in the passphrase
     #[arg(short, long, default_value = " ")]
     separator: String,
 
+    /// A path to a dictionary file. A builtin dictionary is used if not provided.
     #[arg(short, long)]
     dict_path: Option<String>,
 }


### PR DESCRIPTION
```
Usage: riceware [OPTIONS]

Options:
  -n, --num-words <NUM_WORDS>  The number of words in the passphrase [default: 4]
  -s, --separator <SEPARATOR>  The string to separate words in the passphrase [default: " "]
  -d, --dict-path <DICT_PATH>  A path to a dictionary file. A builtin dictionary is used if not provided
  -h, --help                   Print help
  -V, --version                Print version
```