### PR TITLE
Update clippy CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,4 +27,4 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
-    - run: cargo clippy --all-targets -- -D warnings -D clippy::pedantic -D clippy::all
+    - run: cargo clippy --all-targets


### PR DESCRIPTION
Now we use Cargo.toml to store the clippy config, we don't need to pass flags to clippy in CI anymore.